### PR TITLE
Fixed Zoom Issue for iPad

### DIFF
--- a/index.html
+++ b/index.html
@@ -7,7 +7,7 @@
     
     <link rel="stylesheet" href="stylesheets/styles.css">
     <link rel="stylesheet" href="stylesheets/pygment_trac.css">
-    <meta name="viewport" content="width=device-width, initial-scale=1, user-scalable=no">
+    <meta name="viewport" content="width=device-width">
     <!--[if lt IE 9]>
     <script src="//html5shiv.googlecode.com/svn/trunk/html5.js"></script>
     <![endif]-->


### PR DESCRIPTION
When viewing demo page in Portrait mode, then rotating into Landscape mode causes the desktop version of the theme to be used.

By removing the meta tag values that prevent the user from changing the mobile zoom level, the issue is removed.