### PR TITLE
Monospace font not appearing

### DIFF
--- a/stylesheets/styles.css
+++ b/stylesheets/styles.css
@@ -66,7 +66,7 @@ blockquote {
 }
 
 code, pre {
-  font-family:Monaco, Bitstream Vera Sans Mono, Lucida Console, Terminal, monospace;
+  font-family:Monaco, Bitstream Vera Sans Mono, Lucida Console, Terminal, Consolas, Liberation Mono, DejaVu Sans Mono, Courier New, monospace;
   color:#333;
   font-size:12px;
 }


### PR DESCRIPTION
When I was looking at a page using the minimal theme in chromium (Version 41.0.2272.118 (64-bit), arch linux), I was annoyed that it wasn't using a monospace font for code, but when I checked the css it clearly defined monospace fonts. It worked in firefox for some reason.

So I added a few extra monospace fonts and would like to fix it too for others, namly:

* Consolas
* Liberation Mono
* DejaVu Sans Mono
* Courier New

**This is how it looked like before:**
>![2015-04-15-144704_1920x1080_scrot](https://cloud.githubusercontent.com/assets/6370419/7159775/d80e5066-e384-11e4-8f0d-2461a047dda6.png)

**And afterwards:**
>![2015-04-15-150544_1920x1080_scrot](https://cloud.githubusercontent.com/assets/6370419/7159776/d8285290-e384-11e4-8790-bd1d470c85af.png)

