### PR TITLE
Change text color from #727272 to #595959

### DIFF
--- a/stylesheets/styles.css
+++ b/stylesheets/styles.css
@@ -4,7 +4,7 @@ body {
   background-color: #fff;
   padding:50px;
   font: 14px/1.5 "Noto Sans", "Helvetica Neue", Helvetica, Arial, sans-serif;
-  color:#727272;
+  color:#595959;
   font-weight:400;
 }
 


### PR DESCRIPTION
As mentioned in Issue #1 this is the lightest color for gray text to pass WCAG

There are other places on the website where the contrast is not as good, but
these problems can be addressed later.