### PR TITLE
remove fixed font size in <code> and <pre>

### DIFF
--- a/stylesheets/styles.css
+++ b/stylesheets/styles.css
@@ -69,7 +69,6 @@ blockquote {
 code, pre {
   font-family:Monaco, Bitstream Vera Sans Mono, Lucida Console, Terminal, Consolas, Liberation Mono, DejaVu Sans Mono, Courier New, monospace;
   color:#333;
-  font-size:12px;
 }
 
 pre {


### PR DESCRIPTION
As mentioned in #28, font size for `<code>` and `<pre>` shouldn’t be fixed.

This is to avoid issues when using them inside other elements that have a different size.