### PR TITLE
add link to theme files

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,9 @@
 
 [Demo the Theme](http://orderedlist.github.com/minimal/)
 
-This is the raw HTML and styles that are used for the *minimal* theme on [GitHub Pages](http://pages.github.com/).
+This is the raw HTML and styles that are used to demo the *minimal* theme on [GitHub Pages](http://pages.github.com/).
+
+The default layouts and theme files live at [pages-themes/minimal](https://github.com/pages-themes/minimal)
 
 Syntax highlighting is provided on GitHub Pages by [Pygments](http://pygments.org).
 


### PR DESCRIPTION
I want to modify the default layout, which is trivial if I have access to the original `_layouts/default.html` but it's really not obvious where to find that from here or from a site with the theme implemented. Adding a pointer to the actual theme files will help folks like #29   get what they need. And I think it's probably a good compromise resolution to #23